### PR TITLE
add: dev: Support for route params with regexp validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // var debug = require('debug')('express-list-endpoints')
-var regexpExpressRegexp = /^\/\^\\\/(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\(\[\^\\\/]\+\?\)\)))\\\/.*/
-var regexpExpressParam = /\(\?:\(\[\^\\\/]\+\?\)\)/g
+var regexpExpressRegexp = /^\/\^\\\/(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\(\[\^\\\/]\+\?\)\)|\(\?:\(\[0-9]\+\)\)))\\\/.*/
+var regexpExpressParam = /(\(\?:\(\[\^\\\/]\+\?\)\)|\(\?:\(\[0-9]\+\)\))/g
 
 /**
  * Returns all the verbs detected for the passed route
@@ -46,15 +46,15 @@ var parseExpressPath = function (expressPathRegexp, params) {
 
     parsedRegexp = parsedRegexp
       .toString()
-      .replace(/\(\?:\(\[\^\\\/]\+\?\)\)/, paramId)
+      .replace(/(\(\?:\(\[\^\\\/]\+\?\)\)|\(\?:\(\[0-9]\+\)\))/, paramId)
+      // .replace(/(\(\?:\(\[\^\\\/]\+\?\)\))/, paramId)
+      // .replace(/(?:\(\?:(\(\[0-9]\+\))\))/, `${paramId}$1`)
 
     paramIdx++
   }
-
   if (parsedRegexp !== expressPathRegexp) {
     parsedPath = regexpExpressRegexp.exec(parsedRegexp)
   }
-
   parsedPath = parsedPath[1].replace(/\\\//g, '/')
 
   return parsedPath
@@ -74,7 +74,6 @@ var parseEndpoints = function (app, basePath, endpoints) {
     } else if (stackItem.name === 'router' || stackItem.name === 'bound dispatch') {
       if (regexpExpressRegexp.test(stackItem.regexp)) {
         var parsedPath = parseExpressPath(stackItem.regexp, stackItem.keys)
-
         parseEndpoints(stackItem.handle, basePath + '/' + parsedPath, endpoints)
       } else {
         parseEndpoints(stackItem.handle, basePath, endpoints)

--- a/test/test.js
+++ b/test/test.js
@@ -174,12 +174,14 @@ describe('express-list-endpoints', function () {
         app.use('/router', router)
 
         router.use('/:postId/sub-router', subRouter)
+        router.use('/:postId([0-9]+)/sub-router2', subRouter)
 
         endpoints = listEndpoints(app)
 
         it('should parse the endpoints corretly', function () {
-          expect(endpoints).to.have.length(1)
+          expect(endpoints).to.have.length(2)
           expect(endpoints[0].path).to.be.equal('/router/:postId/sub-router')
+          expect(endpoints[1].path).to.be.equal('/router/:postId/sub-router2')
         })
       })
     })


### PR DESCRIPTION
Fix unmatching routes with digit pattern validation, example: `/^\/(?:([0-9]+))\/level\/sublevel\/?(?=\/|$)/i` was not being recognized as a route