### PR TITLE
Add the complete path to the route object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ var parseEndpoints = function (app, basePath, endpoints) {
     if (stackItem.route) {
       var endpoint = parseExpressRoute(stackItem.route, basePath);
 
-      stackItem.route.jfpath = endpoint.path;
+      stackItem.route.completePath = endpoint.path;
 
       endpoints = addEndpoint(endpoints, endpoint)
     } else if (stackItem.name === 'router' || stackItem.name === 'bound dispatch') {

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,9 @@ var parseEndpoints = function (app, basePath, endpoints) {
 
   stack.forEach(function (stackItem) {
     if (stackItem.route) {
-      var endpoint = parseExpressRoute(stackItem.route, basePath)
+      var endpoint = parseExpressRoute(stackItem.route, basePath);
+
+      stackItem.route.jfpath = endpoint.path;
 
       endpoints = addEndpoint(endpoints, endpoint)
     } else if (stackItem.name === 'router' || stackItem.name === 'bound dispatch') {


### PR DESCRIPTION
Adding the complete route path to the route object makes it available to each incoming http request which is useful for prometheus metrics...