### PR TITLE
Add support for route param regexps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mocha": "^9.0.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
-const regExpToParseExpressPathRegExp = /^\/\^\\\/(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\(\[\^\\\/]\+\?\)\)))\\\/.*/
-const regExpToReplaceExpressPathRegExpParams = /\(\?:\(\[\^\\\/]\+\?\)\)/
-const regexpExpressParamRegexp = /\(\?:\(\[\^\\\/]\+\?\)\)/g
+const regExpToParseExpressPathRegExp = /^\/\^\\\/(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\([^)]+\)\)))\\\/.*/
+const regExpToReplaceExpressPathRegExpParams = /\(\?:\([^)]+\)\)/
+const regexpExpressParamRegexp = /\(\?:\([^)]+\)\)/g
+const regexpExpressPathParamRegexp = /(:[^)]+)\([^)]+\)/g
 
 const EXPRESS_ROOT_PATH_REGEXP_VALUE = '/^\\/?(?=\\/|$)/i'
 const STACK_ITEM_VALID_NAMES = [
@@ -62,7 +63,7 @@ const parseExpressRoute = function (route, basePath) {
       : `${basePath}${path}`
 
     const endpoint = {
-      path: completePath,
+      path: completePath.replace(regexpExpressPathParamRegexp, '$1'),
       methods: getRouteMethods(route),
       middlewares: getRouteMiddlewares(route)
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -598,4 +598,118 @@ describe('express-list-endpoints', () => {
       expect(endpoints[1].middlewares).to.have.length(0)
     })
   })
+
+  describe('supports regexp validators for params', () => {
+    let endpoints
+
+    before(() => {
+      const app = express()
+
+      app.get('/foo/:item_id(\\d+)/bar', (req, res) => {
+        res.end()
+      })
+
+      endpoints = listEndpoints(app)
+    })
+
+    it('should list routes correctly', () => {
+      expect(endpoints).to.have.length(1)
+      expect(endpoints[0].path).to.be.equal('/foo/:item_id/bar')
+      expect(endpoints[0].methods[0]).to.be.equal('GET')
+      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+    })
+  })
+
+  describe('supports multiple regexp validators for params', () => {
+    let endpoints
+
+    before(() => {
+      const app = express()
+
+      app.get('/foo/bar/:baz_id(\\d+)/:biz_id(\\d+)', (req, res) => {
+        res.end()
+      })
+
+      endpoints = listEndpoints(app)
+    })
+
+    it('should list routes correctly', () => {
+      expect(endpoints).to.have.length(1)
+      expect(endpoints[0].path).to.be.equal('/foo/bar/:baz_id/:biz_id')
+      expect(endpoints[0].methods[0]).to.be.equal('GET')
+      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+    })
+  })
+
+  describe('supports regexp validators for params with subapp', () => {
+    let endpoints
+
+    before(() => {
+      const app = express()
+      const subApp = express.Router()
+
+      subApp.get('/baz', (req, res) => {
+        res.end()
+      })
+
+      app.use('/foo/:item_id(\\d+)/bar', subApp)
+
+      endpoints = listEndpoints(app)
+    })
+
+    it('should list routes correctly', () => {
+      expect(endpoints).to.have.length(1)
+      expect(endpoints[0].path).to.be.equal('/foo/:item_id/bar/baz')
+      expect(endpoints[0].methods[0]).to.be.equal('GET')
+      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+    })
+  })
+
+  describe('supports regexp validators for params in subapp', () => {
+    let endpoints
+
+    before(() => {
+      const app = express()
+      const subApp = express.Router()
+
+      subApp.get('/baz/:biz_id(\\d+)', (req, res) => {
+        res.end()
+      })
+
+      app.use('/foo/bar', subApp)
+
+      endpoints = listEndpoints(app)
+    })
+
+    it('should list routes correctly', () => {
+      expect(endpoints).to.have.length(1)
+      expect(endpoints[0].path).to.be.equal('/foo/bar/baz/:biz_id')
+      expect(endpoints[0].methods[0]).to.be.equal('GET')
+      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+    })
+  })
+
+  describe('supports multiple regexp validators for params in subapp', () => {
+    let endpoints
+
+    before(() => {
+      const app = express()
+      const subApp = express.Router()
+
+      subApp.get('/bar/:baz_id(\\d+)/:biz_id(\\d+)', (req, res) => {
+        res.end()
+      })
+
+      app.use('/foo', subApp)
+
+      endpoints = listEndpoints(app)
+    })
+
+    it('should list routes correctly', () => {
+      expect(endpoints).to.have.length(1)
+      expect(endpoints[0].path).to.be.equal('/foo/bar/:baz_id/:biz_id')
+      expect(endpoints[0].methods[0]).to.be.equal('GET')
+      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+    })
+  })
 })


### PR DESCRIPTION
This PR adds support for routes that use regular expressions to validate route parameters, as documented on https://expressjs.com/en/guide/routing.html:

> To have more control over the exact string that can be matched by a route parameter, you can append a regular expression in parentheses (`()`):

I've included a number of tests that failed on the `develop` branch but that now succeed.

It looks like this may close #72?