### PR TITLE
Ensure compatibility with latest versions of Express

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -15,96 +16,117 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Dev
 -->
 
+## [UNRELEASED]
+
+### Fixed
+
+- Add compatibility with express 4.20 and above.
+
 ## v7.1.0 - 2024-04-07
 
 ### Added
+
 - Add logic for apps and routers with no routes to return an empty array.
 
 ### Dev
+
 - Add TypeScript configuration and transpilation scripts.
 - Add types.
 
 ## v7.0.0 - 2024-04-06
 
 ### Added
+
 - Add support for NodeJS v18 and v20.
 - Add support for route param regexps.
 
 ### Deprecated
-- **BREAKING CHANGE** Drop support for NodeJS v12, v14 and v16.
 
+- **BREAKING CHANGE** Drop support for NodeJS v12, v14 and v16.
 
 ## v6.0.0 - 2021-07-29
 
 ### Deprecated
+
 - **BREAKING CHANGE** Drop support for NodeJS v10
 
 ### Fixed
+
 - Fixed a problem when parsing the property `middlewares` for each endpoint being allocated in `middleware` property instead
 
 ### Dev
+
 - Added CI using [GitHub Actions](https://docs.github.com/en/actions)
 - Update dev dependencies
 - Removed TravisCI from the project
 - Refactor code to use new JS methods and improve readability
 
-
 ## v5.0.0 - 2020-07-12
 
 ### Added
+
 - `mounted_app` is being parsed
 - Request handlers mounted on multiple routes by passing an array are being parsed
 - If a route path contains an unparseable regexp it is used to compose the path
 
 ### Changed
+
 - Added `middlewares` property in reports representing mounted middlewares by their name
 
 ### Fixed
+
 - Avoid method duplicity in the same path
 
 ### Deprecated
+
 - **BREAKING** Drop support for NodeJS v6 and v8
 - Drop support for `yarn.lock` file
 
 ### Dev
+
 - Update dev dependencies
 - Improve tests structure
 
-
 ## v4.0.1 - 2019-05-06
-### Fixed
-- Add logic to avoid duplicate paths #40
 
+### Fixed
+
+- Add logic to avoid duplicate paths #40
 
 ## v4.0.0 - 2018-10-14
 
 ### Changed
+
 - Replace build script that versions the changelog for [`changelog-version`](https://www.npmjs.com/package/changelog-version) package #36
 - Update devDependencies
 - Improve code readability
 
 ### BREAKING CHANGES
-- Drop support for NodeJS v4
 
+- Drop support for NodeJS v4
 
 ## v3.0.1 - 2017-10-25
 
 ### 🐛 Fixed
+
 - Fix params on Base route with multi-level routing
 
 ### Changed
-- Update devDependencies
 
+- Update devDependencies
 
 ## v3.0.0 - 2016-12-18
 
 ### BREAKING CHANGES
+
 - Removed support for Node v0.12
 
 ### 🐛 Fixed
+
 - Now the params set in middle of a pattern get parsed #17
 
 ### Dev
+
 - Move main file to `src` folder
 - Add lint script
 - Ignore editorconfig file for npm relases
@@ -112,25 +134,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Implemented [Yarn](https://yarnpkg.com) on the project #19
 
 ### Changed
-- Add more test cases.
 
+- Add more test cases.
 
 ## v2.0.3 - 2016-11-05
 
 ### 🐛 Fixed
-- Super multi-level baseRoutes handled #10
 
+- Super multi-level baseRoutes handled #10
 
 ## v2.0.1 - 2016-11-05
 
 ### Changed
+
 - Update dependencies
 - Fix typos in README file #6
 - Improve README file #7
 
 ### Fixed 🐛
-- Multi-level basePaths are now parsed correctly #10
 
+- Multi-level basePaths are now parsed correctly #10
 
 ## 2.0.0 - 2016-04-24
 
@@ -144,23 +167,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now express is a development dependency
 - Improved tests
 
-
 ## 1.1.0 - 2016-04-20
 
 - Improved regexp to parse express router. #1
 - Added [editorconfig](http://editorconfig.org) file.
 
-
 ## 1.0.1 - 2016-01-18
 
 - Update package version
-
 
 ## 1.0.0 - 2016-01-18
 
 - Add changelog file
 - Improve README file
-
 
 ## 0.0.0 - 2016-01-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.1.1",
-        "express": "^4.19.2",
+        "express": "^4.21.0",
+        "express4-19-2": "npm:express@4.19.2",
         "mocha": "^10.4.0",
         "rimraf": "^5.0.5",
         "typescript": "^5.4.4"
@@ -601,10 +602,11 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -614,7 +616,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -629,6 +631,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1123,10 +1126,11 @@
       "dev": true
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1834,10 +1838,64 @@
       }
     },
     "node_modules/express": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.6.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.10",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express4-19-2": {
+      "name": "express",
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
       "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1875,13 +1933,146 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/debug": {
+    "node_modules/express4-19-2/node_modules/body-parser": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/express4-19-2/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/express4-19-2/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express4-19-2/node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express4-19-2/node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/express4-19-2/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/express4-19-2/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express4-19-2/node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express4-19-2/node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/express4-19-2/node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1936,13 +2127,14 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -1958,6 +2150,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -2976,10 +3169,14 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -3433,10 +3630,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -3500,12 +3698,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -3776,10 +3975,11 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3804,6 +4004,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3812,13 +4013,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -3830,15 +4043,16 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "express": "^4.19.2",
+    "express4-19-2": "npm:express@4.19.2",
+    "express": "^4.21.0",
     "mocha": "^10.4.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.4.4"

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,9 @@
  * @property {string[]} middlewares Mounted middlewares
  */
 
-const regExpToParseExpressPathRegExp = /^\/\^\\\/(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\([^)]+\)\)))\\\/.*/
-const regExpToReplaceExpressPathRegExpParams = /\(\?:\([^)]+\)\)/
-const regexpExpressParamRegexp = /\(\?:\([^)]+\)\)/g
+const regExpToParseExpressPathRegExp = /^\/\^\\?\/?(?:(:?[\w\\.-]*(?:\\\/:?[\w\\.-]*)*)|(\(\?:\\?\/?\([^)]+\)\)))\\\/.*/
+const regExpToReplaceExpressPathRegExpParams = /\(\?:\\?\/?\([^)]+\)\)/
+const regexpExpressParamRegexp = /\(\?:\\?\\?\/?\([^)]+\)\)/g
 const regexpExpressPathParamRegexp = /(:[^)]+)\([^)]+\)/g
 
 const EXPRESS_ROOT_PATH_REGEXP_VALUE = '/^\\/?(?=\\/|$)/i'
@@ -104,7 +104,17 @@ const parseExpressPath = function (expressPathRegExp, params) {
     const paramId = `:${paramName}`
 
     parsedRegExp = parsedRegExp
-      .replace(regExpToReplaceExpressPathRegExpParams, paramId)
+      .replace(regExpToReplaceExpressPathRegExpParams, (str) => {
+        // Express >= 4.20.0 uses a different RegExp for parameters: it
+        // captures the slash as part of the parameter. We need to check
+        // for this case and add the slash to the value that will replace
+        // the parameter in the path.
+        if (str.startsWith('(?:\\/')) {
+          return `\\/${paramId}`
+        }
+
+        return paramId
+      })
 
     paramIndex++
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,7 +2,6 @@
 const mocha = require('mocha')
 const chai = require('chai')
 const listEndpoints = require('../src/index')
-const express = require('express')
 
 const before = mocha.before
 const expect = chai.expect
@@ -33,613 +32,626 @@ function assertResult (endpoints) {
   })
 }
 
-describe('express-list-endpoints', () => {
-  describe('when called with non configured app', () => {
-    let endpoints
+const expressVersions = [
+  {
+    version: '4.19.2',
+    express: require('express4-19-2')
+  },
+  {
+    version: 'latest',
+    express: require('express')
+  }
+]
 
-    before(() => {
-      const app = express()
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should return an empty array', () => {
-      endpoints.should.be.an('array')
-      endpoints.should.have.length(0)
-    })
-  })
-
-  describe('when called over an app', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-
-      app.route('/')
-        .get((req, res) => {
-          res.end()
-        })
-        .all((req, res) => {
-          res.end()
-        })
-        .post((req, res) => {
-          res.end()
-        })
-
-      app.route('/testing')
-        .all((req, res) => {
-          res.end()
-        })
-        .delete((req, res) => {
-          res.end()
-        })
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should return an array of well formed objects', () => {
-      assertResult(endpoints)
-    })
-  })
-
-  describe('when called over a router', () => {
-    let endpoints
-
-    before(() => {
-      const router = express.Router()
-
-      router.route('/')
-        .get((req, res) => {
-          res.end()
-        })
-        .all((req, res) => {
-          res.end()
-        })
-        .post((req, res) => {
-          res.end()
-        })
-
-      router.route('/testing')
-        .all((req, res) => {
-          res.end()
-        })
-        .delete((req, res) => {
-          res.end()
-        })
-
-      endpoints = listEndpoints(router)
-    })
-
-    it('should return an array of well formed objects', () => {
-      assertResult(endpoints)
-    })
-  })
-
-  describe('when called over an app with mounted routers', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-      const router = express.Router()
-
-      app.route('/testing')
-        .all((req, res) => {
-          res.end()
-        })
-        .delete((req, res) => {
-          res.end()
-        })
-
-      router.route('/')
-        .get((req, res) => {
-          res.end()
-        })
-        .all((req, res) => {
-          res.end()
-        })
-        .post((req, res) => {
-          res.end()
-        })
-
-      app.use('/router', router)
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should return an array of well formed objects', () => {
-      assertResult(endpoints)
-    })
-
-    describe('and some of the routers has the option `mergeParams`', () => {
+for (const { version, express } of expressVersions) {
+  describe(`express-list-endpoints, express@${version}`, () => {
+    describe('when called with non configured app', () => {
       let endpoints
 
       before(() => {
         const app = express()
-        const router = express.Router({ mergeParams: true })
 
-        router.get('/:id/friends', (req, res) => {
-          res.end()
-        })
+        endpoints = listEndpoints(app)
+      })
+
+      it('should return an empty array', () => {
+        endpoints.should.be.an('array')
+        endpoints.should.have.length(0)
+      })
+    })
+
+    describe('when called over an app', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+
+        app.route('/')
+          .get((req, res) => {
+            res.end()
+          })
+          .all((req, res) => {
+            res.end()
+          })
+          .post((req, res) => {
+            res.end()
+          })
+
+        app.route('/testing')
+          .all((req, res) => {
+            res.end()
+          })
+          .delete((req, res) => {
+            res.end()
+          })
+
+        endpoints = listEndpoints(app)
+      })
+
+      it('should return an array of well formed objects', () => {
+        assertResult(endpoints)
+      })
+    })
+
+    describe('when called over a router', () => {
+      let endpoints
+
+      before(() => {
+        const router = express.Router()
+
+        router.route('/')
+          .get((req, res) => {
+            res.end()
+          })
+          .all((req, res) => {
+            res.end()
+          })
+          .post((req, res) => {
+            res.end()
+          })
+
+        router.route('/testing')
+          .all((req, res) => {
+            res.end()
+          })
+          .delete((req, res) => {
+            res.end()
+          })
+
+        endpoints = listEndpoints(router)
+      })
+
+      it('should return an array of well formed objects', () => {
+        assertResult(endpoints)
+      })
+    })
+
+    describe('when called over an app with mounted routers', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+        const router = express.Router()
+
+        app.route('/testing')
+          .all((req, res) => {
+            res.end()
+          })
+          .delete((req, res) => {
+            res.end()
+          })
+
+        router.route('/')
+          .get((req, res) => {
+            res.end()
+          })
+          .all((req, res) => {
+            res.end()
+          })
+          .post((req, res) => {
+            res.end()
+          })
 
         app.use('/router', router)
 
         endpoints = listEndpoints(app)
       })
 
-      it('should parse the endpoints correctly', () => {
-        expect(endpoints).to.have.length(1)
-        expect(endpoints[0].path).to.be.equal('/router/:id/friends')
+      it('should return an array of well formed objects', () => {
+        assertResult(endpoints)
       })
 
-      describe('and also has a sub-router on the router', () => {
+      describe('and some of the routers has the option `mergeParams`', () => {
         let endpoints
 
         before(() => {
           const app = express()
           const router = express.Router({ mergeParams: true })
-          const subRouter = express.Router()
 
-          subRouter.get('/', (req, res) => {
+          router.get('/:id/friends', (req, res) => {
             res.end()
           })
 
           app.use('/router', router)
-
-          router.use('/:postId/sub-router', subRouter)
 
           endpoints = listEndpoints(app)
         })
 
         it('should parse the endpoints correctly', () => {
           expect(endpoints).to.have.length(1)
-          expect(endpoints[0].path).to.be.equal('/router/:postId/sub-router')
+          expect(endpoints[0].path).to.be.equal('/router/:id/friends')
+        })
+
+        describe('and also has a sub-router on the router', () => {
+          let endpoints
+
+          before(() => {
+            const app = express()
+            const router = express.Router({ mergeParams: true })
+            const subRouter = express.Router()
+
+            subRouter.get('/', (req, res) => {
+              res.end()
+            })
+
+            app.use('/router', router)
+
+            router.use('/:postId/sub-router', subRouter)
+
+            endpoints = listEndpoints(app)
+          })
+
+          it('should parse the endpoints correctly', () => {
+            expect(endpoints).to.have.length(1)
+            expect(endpoints[0].path).to.be.equal('/router/:postId/sub-router')
+          })
         })
       })
     })
-  })
 
-  describe('when the defined routes', () => {
-    describe('contains underscores', () => {
-      let endpoints
+    describe('when the defined routes', () => {
+      describe('contains underscores', () => {
+        let endpoints
 
-      before(() => {
-        const router = express.Router()
+        before(() => {
+          const router = express.Router()
 
-        router.get('/some_route', (req, res) => {
-          res.end()
+          router.get('/some_route', (req, res) => {
+            res.end()
+          })
+
+          router.get('/some_other_router', (req, res) => {
+            res.end()
+          })
+
+          router.get('/__last_route__', (req, res) => {
+            res.end()
+          })
+
+          endpoints = listEndpoints(router)
         })
 
-        router.get('/some_other_router', (req, res) => {
-          res.end()
+        it('should parse the endpoint correctly', () => {
+          endpoints[0].path.should.be.equal('/some_route')
+          endpoints[1].path.should.be.equal('/some_other_router')
+          endpoints[2].path.should.be.equal('/__last_route__')
         })
-
-        router.get('/__last_route__', (req, res) => {
-          res.end()
-        })
-
-        endpoints = listEndpoints(router)
       })
 
-      it('should parse the endpoint correctly', () => {
-        endpoints[0].path.should.be.equal('/some_route')
-        endpoints[1].path.should.be.equal('/some_other_router')
-        endpoints[2].path.should.be.equal('/__last_route__')
+      describe('contains hyphens', () => {
+        let endpoints
+
+        before(() => {
+          const router = express.Router()
+
+          router.get('/some-route', (req, res) => {
+            res.end()
+          })
+
+          router.get('/some-other-router', (req, res) => {
+            res.end()
+          })
+
+          router.get('/--last-route--', (req, res) => {
+            res.end()
+          })
+
+          endpoints = listEndpoints(router)
+        })
+
+        it('should parse the endpoint correctly', () => {
+          endpoints[0].path.should.be.equal('/some-route')
+          endpoints[1].path.should.be.equal('/some-other-router')
+          endpoints[2].path.should.be.equal('/--last-route--')
+        })
+      })
+
+      describe('contains dots', () => {
+        let endpoints
+
+        before(() => {
+          const router = express.Router()
+
+          router.get('/some.route', (req, res) => {
+            res.end()
+          })
+
+          router.get('/some.other.router', (req, res) => {
+            res.end()
+          })
+
+          router.get('/..last.route..', (req, res) => {
+            res.end()
+          })
+
+          endpoints = listEndpoints(router)
+        })
+
+        it('should parse the endpoint correctly', () => {
+          endpoints[0].path.should.be.equal('/some.route')
+          endpoints[1].path.should.be.equal('/some.other.router')
+          endpoints[2].path.should.be.equal('/..last.route..')
+        })
+      })
+
+      describe('contains multiple different chars', () => {
+        let endpoints
+
+        before(() => {
+          const router = express.Router()
+
+          router.get('/s0m3_r.oute', (req, res) => {
+            res.end()
+          })
+
+          router.get('/v1.0.0', (req, res) => {
+            res.end()
+          })
+
+          router.get('/not_sure.what-1m.d01ng', (req, res) => {
+            res.end()
+          })
+
+          endpoints = listEndpoints(router)
+        })
+
+        it('should parse the endpoint correctly', () => {
+          endpoints[0].path.should.be.equal('/s0m3_r.oute')
+          endpoints[1].path.should.be.equal('/v1.0.0')
+          endpoints[2].path.should.be.equal('/not_sure.what-1m.d01ng')
+        })
       })
     })
 
-    describe('contains hyphens', () => {
-      let endpoints
-
-      before(() => {
-        const router = express.Router()
-
-        router.get('/some-route', (req, res) => {
-          res.end()
-        })
-
-        router.get('/some-other-router', (req, res) => {
-          res.end()
-        })
-
-        router.get('/--last-route--', (req, res) => {
-          res.end()
-        })
-
-        endpoints = listEndpoints(router)
-      })
-
-      it('should parse the endpoint correctly', () => {
-        endpoints[0].path.should.be.equal('/some-route')
-        endpoints[1].path.should.be.equal('/some-other-router')
-        endpoints[2].path.should.be.equal('/--last-route--')
-      })
-    })
-
-    describe('contains dots', () => {
-      let endpoints
-
-      before(() => {
-        const router = express.Router()
-
-        router.get('/some.route', (req, res) => {
-          res.end()
-        })
-
-        router.get('/some.other.router', (req, res) => {
-          res.end()
-        })
-
-        router.get('/..last.route..', (req, res) => {
-          res.end()
-        })
-
-        endpoints = listEndpoints(router)
-      })
-
-      it('should parse the endpoint correctly', () => {
-        endpoints[0].path.should.be.equal('/some.route')
-        endpoints[1].path.should.be.equal('/some.other.router')
-        endpoints[2].path.should.be.equal('/..last.route..')
-      })
-    })
-
-    describe('contains multiple different chars', () => {
-      let endpoints
-
-      before(() => {
-        const router = express.Router()
-
-        router.get('/s0m3_r.oute', (req, res) => {
-          res.end()
-        })
-
-        router.get('/v1.0.0', (req, res) => {
-          res.end()
-        })
-
-        router.get('/not_sure.what-1m.d01ng', (req, res) => {
-          res.end()
-        })
-
-        endpoints = listEndpoints(router)
-      })
-
-      it('should parse the endpoint correctly', () => {
-        endpoints[0].path.should.be.equal('/s0m3_r.oute')
-        endpoints[1].path.should.be.equal('/v1.0.0')
-        endpoints[2].path.should.be.equal('/not_sure.what-1m.d01ng')
-      })
-    })
-  })
-
-  describe('when called over a mounted router with only root path', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-      const router = express.Router()
-
-      router.get('/', (req, res) => {
-        res.end()
-      })
-
-      app.use('/', router)
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should retrieve the list of endpoints and its methods', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0]).to.have.own.property('path')
-      expect(endpoints[0]).to.have.own.property('methods')
-      expect(endpoints[0].path).to.be.equal('/')
-      expect(endpoints[0].methods[0]).to.be.equal('GET')
-    })
-  })
-
-  describe('when called over a multi-level base route', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-      const router = express.Router()
-
-      router.get('/my/path', (req, res) => {
-        res.end()
-      })
-
-      app.use('/multi/level', router)
-      app.use('/super/duper/multi/level', router)
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should retrieve the correct built path', () => {
-      expect(endpoints).to.have.length(2)
-      expect(endpoints[0].path).to.be.equal('/multi/level/my/path')
-      expect(endpoints[1].path).to.be.equal('/super/duper/multi/level/my/path')
-    })
-
-    describe('with params', () => {
+    describe('when called over a mounted router with only root path', () => {
       let endpoints
 
       before(() => {
         const app = express()
         const router = express.Router()
 
-        router.get('/users/:id', (req, res) => {
+        router.get('/', (req, res) => {
           res.end()
         })
 
-        router.get('/super/users/:id', (req, res) => {
+        app.use('/', router)
+
+        endpoints = listEndpoints(app)
+      })
+
+      it('should retrieve the list of endpoints and its methods', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0]).to.have.own.property('path')
+        expect(endpoints[0]).to.have.own.property('methods')
+        expect(endpoints[0].path).to.be.equal('/')
+        expect(endpoints[0].methods[0]).to.be.equal('GET')
+      })
+    })
+
+    describe('when called over a multi-level base route', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+        const router = express.Router()
+
+        router.get('/my/path', (req, res) => {
           res.end()
         })
 
-        app.use('/multi/:multiId/level/:levelId', router)
+        app.use('/multi/level', router)
+        app.use('/super/duper/multi/level', router)
 
         endpoints = listEndpoints(app)
       })
 
       it('should retrieve the correct built path', () => {
         expect(endpoints).to.have.length(2)
-        expect(endpoints[0].path).to.be.equal('/multi/:multiId/level/:levelId/users/:id')
-        expect(endpoints[1].path).to.be.equal('/multi/:multiId/level/:levelId/super/users/:id')
+        expect(endpoints[0].path).to.be.equal('/multi/level/my/path')
+        expect(endpoints[1].path).to.be.equal('/super/duper/multi/level/my/path')
+      })
+
+      describe('with params', () => {
+        let endpoints
+
+        before(() => {
+          const app = express()
+          const router = express.Router()
+
+          router.get('/users/:id', (req, res) => {
+            res.end()
+          })
+
+          router.get('/super/users/:id', (req, res) => {
+            res.end()
+          })
+
+          app.use('/multi/:multiId/level/:levelId', router)
+
+          endpoints = listEndpoints(app)
+        })
+
+        it('should retrieve the correct built path', () => {
+          expect(endpoints).to.have.length(2)
+          expect(endpoints[0].path).to.be.equal('/multi/:multiId/level/:levelId/users/:id')
+          expect(endpoints[1].path).to.be.equal('/multi/:multiId/level/:levelId/super/users/:id')
+        })
+      })
+
+      describe('with params in middle of the pattern', () => {
+        let endpoints
+
+        before(() => {
+          const app = express()
+          const router = express.Router()
+
+          router.get('/super/users/:id/friends', (req, res) => {
+            res.end()
+          })
+
+          app.use('/multi/level', router)
+
+          endpoints = listEndpoints(app)
+        })
+
+        it('should retrieve the correct built path', () => {
+          expect(endpoints).to.have.length(1)
+          expect(endpoints[0].path).to.be.equal('/multi/level/super/users/:id/friends')
+        })
       })
     })
 
-    describe('with params in middle of the pattern', () => {
+    describe('when called over a route with params', () => {
       let endpoints
 
       before(() => {
         const app = express()
-        const router = express.Router()
 
-        router.get('/super/users/:id/friends', (req, res) => {
+        app.get('/users/:id', (req, res) => {
           res.end()
         })
-
-        app.use('/multi/level', router)
 
         endpoints = listEndpoints(app)
       })
 
       it('should retrieve the correct built path', () => {
         expect(endpoints).to.have.length(1)
-        expect(endpoints[0].path).to.be.equal('/multi/level/super/users/:id/friends')
+        expect(endpoints[0].path).to.be.equal('/users/:id')
       })
     })
-  })
 
-  describe('when called over a route with params', () => {
-    let endpoints
+    describe('when called over a route with params in middle of the pattern', () => {
+      let endpoints
 
-    before(() => {
-      const app = express()
+      before(() => {
+        const app = express()
 
-      app.get('/users/:id', (req, res) => {
-        res.end()
-      })
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should retrieve the correct built path', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].path).to.be.equal('/users/:id')
-    })
-  })
-
-  describe('when called over a route with params in middle of the pattern', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-
-      app.get('/users/:id/friends', (req, res) => {
-        res.end()
-      })
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should retrieve the correct built path', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].path).to.be.equal('/users/:id/friends')
-    })
-  })
-
-  describe('when called over a route with multiple methods with "/" path defined', () => {
-    let endpoints
-
-    before(() => {
-      const router = express.Router()
-
-      router
-        .post('/test', (req, res) => {
-          res.end()
-        })
-        .delete('/test', (req, res) => {
+        app.get('/users/:id/friends', (req, res) => {
           res.end()
         })
 
-      endpoints = listEndpoints(router)
-    })
-
-    it('should retrieve the correct built path', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].path).to.be.equal('/test')
-    })
-
-    it('should retrieve the correct built methods', () => {
-      expect(endpoints[0].methods).to.have.length(2)
-      expect(endpoints[0].methods[0]).to.be.equal('POST')
-      expect(endpoints[0].methods[1]).to.be.equal('DELETE')
-    })
-  })
-
-  describe('when called with middlewares', () => {
-    let endpoints
-
-    before(() => {
-      const router = express.Router()
-
-      const exampleMiddleware = () => {}
-
-      router
-        .post('/test', [
-          exampleMiddleware,
-          () => {} // Anonymous middleware
-        ])
-
-      endpoints = listEndpoints(router)
-    })
-
-    it('should retrieve the correct built path', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].path).to.be.equal('/test')
-      expect(endpoints[0].methods[0]).to.be.equal('POST')
-    })
-
-    it('should retrieve the correct middlewares', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].middlewares).to.have.length(2)
-      expect(endpoints[0].middlewares[0]).to.equal('exampleMiddleware')
-      expect(endpoints[0].middlewares[1]).to.equal('anonymous')
-    })
-  })
-
-  describe('when called with an array of paths', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-      const router = express.Router()
-
-      app.get([
-        '/one',
-        '/two'
-      ], (req, res) => {
-        res.end()
+        endpoints = listEndpoints(app)
       })
 
-      router.get([
-        '/one',
-        '/two'
-      ], (req, res) => {
-        res.end()
+      it('should retrieve the correct built path', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0].path).to.be.equal('/users/:id/friends')
       })
-
-      app.use([
-        '/router',
-        '/sub-path'
-      ], router)
-
-      endpoints = listEndpoints(app)
     })
 
-    it('should list routes correctly', () => {
-      expect(endpoints).to.have.length(4)
-      expect(endpoints[0].path).to.be.equal('/one')
-      expect(endpoints[0].methods[0]).to.be.equal('GET')
-      expect(endpoints[1].path).to.be.equal('/two')
-      expect(endpoints[1].methods[0]).to.be.equal('GET')
+    describe('when called over a route with multiple methods with "/" path defined', () => {
+      let endpoints
+
+      before(() => {
+        const router = express.Router()
+
+        router
+          .post('/test', (req, res) => {
+            res.end()
+          })
+          .delete('/test', (req, res) => {
+            res.end()
+          })
+
+        endpoints = listEndpoints(router)
+      })
+
+      it('should retrieve the correct built path', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0].path).to.be.equal('/test')
+      })
+
+      it('should retrieve the correct built methods', () => {
+        expect(endpoints[0].methods).to.have.length(2)
+        expect(endpoints[0].methods[0]).to.be.equal('POST')
+        expect(endpoints[0].methods[1]).to.be.equal('DELETE')
+      })
+    })
+
+    describe('when called with middlewares', () => {
+      let endpoints
+
+      before(() => {
+        const router = express.Router()
+
+        const exampleMiddleware = () => {}
+
+        router
+          .post('/test', [
+            exampleMiddleware,
+            () => {} // Anonymous middleware
+          ])
+
+        endpoints = listEndpoints(router)
+      })
+
+      it('should retrieve the correct built path', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0].path).to.be.equal('/test')
+        expect(endpoints[0].methods[0]).to.be.equal('POST')
+      })
+
+      it('should retrieve the correct middlewares', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0].middlewares).to.have.length(2)
+        expect(endpoints[0].middlewares[0]).to.equal('exampleMiddleware')
+        expect(endpoints[0].middlewares[1]).to.equal('anonymous')
+      })
+    })
+
+    describe('when called with an array of paths', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+        const router = express.Router()
+
+        app.get([
+          '/one',
+          '/two'
+        ], (req, res) => {
+          res.end()
+        })
+
+        router.get([
+          '/one',
+          '/two'
+        ], (req, res) => {
+          res.end()
+        })
+
+        app.use([
+          '/router',
+          '/sub-path'
+        ], router)
+
+        endpoints = listEndpoints(app)
+      })
+
+      it('should list routes correctly', () => {
+        expect(endpoints).to.have.length(4)
+        expect(endpoints[0].path).to.be.equal('/one')
+        expect(endpoints[0].methods[0]).to.be.equal('GET')
+        expect(endpoints[1].path).to.be.equal('/two')
+        expect(endpoints[1].methods[0]).to.be.equal('GET')
+      })
+    })
+
+    describe('when called with an app with a mounted sub-app', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+        const subApp = express()
+
+        app.get('/', (req, res) => {
+          res.end()
+        })
+
+        subApp.get('/', (req, res) => {
+          res.end()
+        })
+
+        app.use('/sub-app', subApp)
+
+        endpoints = listEndpoints(app)
+      })
+
+      it('should list routes correctly', () => {
+        expect(endpoints).to.have.length(2)
+        expect(endpoints[0].path).to.be.equal('/')
+        expect(endpoints[0].methods[0]).to.be.equal('GET')
+        expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+        expect(endpoints[1].path).to.be.equal('/sub-app')
+        expect(endpoints[1].methods).to.have.length(0)
+        expect(endpoints[1].middlewares).to.have.length(0)
+      })
+    })
+
+    describe('when called with route params with regexp', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+
+        app.get('/foo/:item_id(\\d+)/bar', (req, res) => {
+          res.end()
+        })
+
+        endpoints = listEndpoints(app)
+      })
+
+      it('should list routes correctly', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0].path).to.be.equal('/foo/:item_id/bar')
+        expect(endpoints[0].methods[0]).to.be.equal('GET')
+        expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+      })
+    })
+
+    describe('when called with a route with multiple params with regexp', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+
+        app.get('/foo/bar/:baz_id(\\d+)/:biz_id(\\d+)', (req, res) => {
+          res.end()
+        })
+
+        endpoints = listEndpoints(app)
+      })
+
+      it('should list routes correctly', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0].path).to.be.equal('/foo/bar/:baz_id/:biz_id')
+        expect(endpoints[0].methods[0]).to.be.equal('GET')
+        expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+      })
+    })
+
+    describe('supports regexp validators for params in subapp', () => {
+      let endpoints
+
+      before(() => {
+        const app = express()
+        const subApp = express.Router()
+
+        subApp.get('/baz/:biz_id(\\d+)', (req, res) => {
+          res.end()
+        })
+
+        app.use('/foo/bar', subApp)
+
+        endpoints = listEndpoints(app)
+      })
+
+      it('should list routes correctly', () => {
+        expect(endpoints).to.have.length(1)
+        expect(endpoints[0].path).to.be.equal('/foo/bar/baz/:biz_id')
+        expect(endpoints[0].methods[0]).to.be.equal('GET')
+        expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
+      })
     })
   })
-
-  describe('when called with an app with a mounted sub-app', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-      const subApp = express()
-
-      app.get('/', (req, res) => {
-        res.end()
-      })
-
-      subApp.get('/', (req, res) => {
-        res.end()
-      })
-
-      app.use('/sub-app', subApp)
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should list routes correctly', () => {
-      expect(endpoints).to.have.length(2)
-      expect(endpoints[0].path).to.be.equal('/')
-      expect(endpoints[0].methods[0]).to.be.equal('GET')
-      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
-      expect(endpoints[1].path).to.be.equal('/sub-app')
-      expect(endpoints[1].methods).to.have.length(0)
-      expect(endpoints[1].middlewares).to.have.length(0)
-    })
-  })
-
-  describe('when called with route params with regexp', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-
-      app.get('/foo/:item_id(\\d+)/bar', (req, res) => {
-        res.end()
-      })
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should list routes correctly', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].path).to.be.equal('/foo/:item_id/bar')
-      expect(endpoints[0].methods[0]).to.be.equal('GET')
-      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
-    })
-  })
-
-  describe('when called with a route with multiple params with regexp', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-
-      app.get('/foo/bar/:baz_id(\\d+)/:biz_id(\\d+)', (req, res) => {
-        res.end()
-      })
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should list routes correctly', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].path).to.be.equal('/foo/bar/:baz_id/:biz_id')
-      expect(endpoints[0].methods[0]).to.be.equal('GET')
-      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
-    })
-  })
-
-  describe('supports regexp validators for params in subapp', () => {
-    let endpoints
-
-    before(() => {
-      const app = express()
-      const subApp = express.Router()
-
-      subApp.get('/baz/:biz_id(\\d+)', (req, res) => {
-        res.end()
-      })
-
-      app.use('/foo/bar', subApp)
-
-      endpoints = listEndpoints(app)
-    })
-
-    it('should list routes correctly', () => {
-      expect(endpoints).to.have.length(1)
-      expect(endpoints[0].path).to.be.equal('/foo/bar/baz/:biz_id')
-      expect(endpoints[0].methods[0]).to.be.equal('GET')
-      expect(endpoints[0].middlewares[0]).to.be.equal('anonymous')
-    })
-  })
-})
+}


### PR DESCRIPTION
The most recent versions of Express (4.20.0 and above) changed the way that route patterns are compiled to regular expressions. This PR introduces compatibility with these new versions, while retaining compatibility with older versions. To prove this to myself, I updated the test suite to run against both old and new versions of Express. I recommend reviewing these changes with whitespace changes hidden so that you can see what actually changed in the tests.